### PR TITLE
article内のコンポーネントが幅狭デバイスではみ出す問題の修正

### DIFF
--- a/src/pages/BlogListPage/BlogListPageMobile.tsx
+++ b/src/pages/BlogListPage/BlogListPageMobile.tsx
@@ -49,9 +49,11 @@ export const BlogListPageMobile: React.FC<{
           <Spacer size={40} />
           <ItemList>
             {blogs.map((blog, i) => {
-              return <Link to={blog.dirName} key={i}>
-                <BlogCard blog={blog} key={i} />
-              </Link>
+              return (
+                <Link to={blog.dirName} key={i}>
+                  <BlogCard blog={blog} key={i} />
+                </Link>
+              )
             })}
           </ItemList>
           <Spacer size={80} />

--- a/src/pages/BlogPage/BlogPageMobile.tsx
+++ b/src/pages/BlogPage/BlogPageMobile.tsx
@@ -55,7 +55,7 @@ export const BlogPageMobile: React.FC<BlogPageProps> = ({
           <Spacer size={32} />
           <PageTitle>{blog.title}</PageTitle>
           <Spacer size={56} />
-          <article>
+          <article style={{ maxWidth: '100%' }}>
             <MarkdownViewer mdText={blog.mdText} />
           </article>
           <Spacer size={64} />

--- a/src/pages/BlogPage/BlogPagePC.tsx
+++ b/src/pages/BlogPage/BlogPagePC.tsx
@@ -52,7 +52,7 @@ export const BlogPagePC: React.FC<BlogPageProps> = ({
           <Spacer size={32} />
           <PageTitle>{blog.title}</PageTitle>
           <Spacer size={56} />
-          <article>
+          <article style={{ maxWidth: '100%' }}>
             <MarkdownViewer mdText={blog.mdText} />
           </article>
           <Spacer size={64} />

--- a/src/utils/components/MdViewer/components/Anchor.css.ts
+++ b/src/utils/components/MdViewer/components/Anchor.css.ts
@@ -7,6 +7,7 @@ export const anchor = style([
   {
     color: color.blue,
     textDecoration: 'underline',
+    wordWrap: 'break-word',
     selectors: {
       '&:visited': {
         color: color.purple,

--- a/src/utils/components/MdViewer/components/Code.css.ts
+++ b/src/utils/components/MdViewer/components/Code.css.ts
@@ -17,5 +17,6 @@ export const inlineCode = style([
     color: color.gray,
     borderRadius: '4px',
     background: color.elevation3,
+    wordWrap: 'break-word',
   },
 ])


### PR DESCRIPTION
https://github.com/Zli-UoA/zli_blog/pull/26#issuecomment-2765013086

変更点
- articleにmax-width: 100%を設定
- Ancherコンポーネントにword-wrap: break-wordを設定
- Codeコンポーネントにword-wrap: break-wordを設定

実機確認
iPhone15

![image](https://github.com/user-attachments/assets/71fa94f3-92d1-48e4-8a2a-11fc7d0305b1)